### PR TITLE
Added some recmmended/default global cuts for Kinematics SBS4 and SBS8

### DIFF
--- a/parse_gmn_rootfiles.cfg
+++ b/parse_gmn_rootfiles.cfg
@@ -1,4 +1,5 @@
 ### Input global cuts to be used in parsing the ROOT files. ###
+
 bb.ps.e>0.15
 endcut
 
@@ -13,3 +14,30 @@ output_dir /volatile/halla/sbs/adr/Rootfiles/gmn_parsed/SBS4/pass0
 
 ####Input direcory: absolute path to where the (mass)replayed ROOT files are located in /volatile or /work. If no input is give, the program will search and try to find the ROOTFILES in /volatile or /work as per the input run parameters namely, pass && kine && sbsfieldscael && target. But it is recommended to give the in input directory as it is the default locations are subjected to change.###
 input_dir 
+
+###J. Boyd's recommended global cuts: ###
+	### Kine 4:
+	### sbs.hcal.nclus>0
+	### bb.ps.nclus>0
+	### bb.sh.nclus>0
+	### abs(bb.tr.vz)<0.08
+	### bb.gem.track.nhits[0]>3
+	### bb.tr.n==1
+	### bb.ps.e>0.135
+	### ((bb.sh.e+bb.ps.e)/(bb.tr.p[0]))>(0.65)&&((bb.sh.e+bb.ps.e)/(bb.tr.p[0]))<(1.30)
+	### sbs.hcal.e>0.02
+	### bb.sh.e+bb.ps.e)>1.55
+	### ((e.kine.W2)>0.55)&&((e.kine.W2)<1.25)
+
+	### Kine 8:
+	### sbs.hcal.nclus>0
+	### bb.ps.nclus>0
+	### bb.sh.nclus>0
+	### abs(bb.tr.vz)<0.08
+	### bb.gem.track.nhits[0]>3
+	### bb.tr.n==1
+	### bb.ps.e>0.175
+	### ((bb.sh.e+bb.ps.e)/(bb.tr.p[0]))>(0.75)&&((bb.sh.e+bb.ps.e)/(bb.tr.p[0]))<(1.25)
+	### sbs.hcal.e>0.025
+	### (bb.sh.e+bb.ps.e)>2.1
+	### ((e.kine.W2)>0.6)&&((e.kine.W2)<1.30)


### PR DESCRIPTION
I think it may help to add some suggestions/default global cut values to the cfg file. I think some of the cfg files often lack proper examples or baseline values. 

Also, the CFG file in the original repository only shows a single cut value of: bb.ps.e>0.15

it would be helpful if the CFG file had an example of multiple cuts

For instance, I can't tell if I need to use a comma or to just go line by line.

For example, is it: " bb.ps.e>0.15, bb.sh.e>1.5" or would it be:

"bb.ps.e>0.15
bb.sh.e>1.5"

Or something else?

For now I am just adding the suggested defaults. 